### PR TITLE
Fix categories

### DIFF
--- a/src/main/java/seedu/taskboss/logic/commands/RenameCategoryCommand.java
+++ b/src/main/java/seedu/taskboss/logic/commands/RenameCategoryCommand.java
@@ -19,8 +19,8 @@ public class RenameCategoryCommand extends Command {
     private final Logger logger = LogsCenter.getLogger(RenameCategoryCommand.class);
 
     private static final String EMPTY_STRING = "";
-    public static final String COMMAND_WORD = "rename";
-    public static final String COMMAND_WORD_SHORT = "r";
+    public static final String COMMAND_WORD = "name";
+    public static final String COMMAND_WORD_SHORT = "n";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + "/" + COMMAND_WORD_SHORT
             + ": Renames an existing category.\n"

--- a/src/main/java/seedu/taskboss/logic/commands/RenameCategoryCommand.java
+++ b/src/main/java/seedu/taskboss/logic/commands/RenameCategoryCommand.java
@@ -1,5 +1,8 @@
 package seedu.taskboss.logic.commands;
 
+import java.util.logging.Logger;
+
+import seedu.taskboss.commons.core.LogsCenter;
 import seedu.taskboss.commons.exceptions.DefaultCategoryException;
 import seedu.taskboss.commons.exceptions.IllegalValueException;
 import seedu.taskboss.logic.commands.exceptions.CommandException;
@@ -13,9 +16,11 @@ import seedu.taskboss.model.category.UniqueCategoryList.DuplicateCategoryExcepti
  */
 public class RenameCategoryCommand extends Command {
 
+    private final Logger logger = LogsCenter.getLogger(RenameCategoryCommand.class);
+
     private static final String EMPTY_STRING = "";
-    public static final String COMMAND_WORD = "name";
-    public static final String COMMAND_WORD_SHORT = "n";
+    public static final String COMMAND_WORD = "rename";
+    public static final String COMMAND_WORD_SHORT = "r";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + "/" + COMMAND_WORD_SHORT
             + ": Renames an existing category.\n"
@@ -35,7 +40,6 @@ public class RenameCategoryCommand extends Command {
     public static final String MESSAGE_DUPLICATE_CATEGORY = "This category already exists in TaskBoss.";
     public static final String MESSAGE_DOES_NOT_EXIST_CATEGORY = "This category does not exist in TaskBoss.";
 
-
     public final String oldCategory;
     public final String newCategory;
 
@@ -53,14 +57,17 @@ public class RenameCategoryCommand extends Command {
         Category newCategory = new Category(this.newCategory);
 
         try {
+            logger.info("Attempting to rename category");
             checkDefaultCategoryViolation(oldCategory, newCategory);
             model.renameCategory(oldCategory, newCategory);
             model.updateFilteredTaskListByCategory(newCategory);
             return new CommandResult(MESSAGE_SUCCESS);
         } catch (DefaultCategoryException dce) {
+            logger.info("User attempted to modify built-in categories' names. Throwing CommandException");
             throwCommandExceptionForDefaultCategory(dce);
             return new CommandResult(EMPTY_STRING); // will never reach this statement
         } catch (DuplicateCategoryException e) {
+            logger.info("User attempted to create duplicate categories. Returning user feedback");
             return new CommandResult(MESSAGE_DUPLICATE_CATEGORY);
         }
     }

--- a/src/main/java/seedu/taskboss/logic/commands/RenameCategoryCommand.java
+++ b/src/main/java/seedu/taskboss/logic/commands/RenameCategoryCommand.java
@@ -68,7 +68,7 @@ public class RenameCategoryCommand extends Command {
             return new CommandResult(EMPTY_STRING); // will never reach this statement
         } catch (DuplicateCategoryException e) {
             logger.info("User attempted to create duplicate categories. Returning user feedback");
-            return new CommandResult(MESSAGE_DUPLICATE_CATEGORY);
+            throw new CommandException(MESSAGE_DUPLICATE_CATEGORY);
         }
     }
 

--- a/src/main/java/seedu/taskboss/model/ModelManager.java
+++ b/src/main/java/seedu/taskboss/model/ModelManager.java
@@ -15,7 +15,6 @@ import seedu.taskboss.commons.events.model.TaskBossChangedEvent;
 import seedu.taskboss.commons.exceptions.IllegalValueException;
 import seedu.taskboss.commons.util.CollectionUtil;
 import seedu.taskboss.commons.util.StringUtil;
-import seedu.taskboss.logic.commands.RenameCategoryCommand;
 import seedu.taskboss.logic.commands.exceptions.CommandException;
 import seedu.taskboss.model.category.Category;
 import seedu.taskboss.model.category.UniqueCategoryList;
@@ -90,6 +89,7 @@ public class ModelManager extends ComponentManager implements Model {
     private void indicateTaskBossChanged() {
         raise(new TaskBossChangedEvent(taskBoss));
     }
+
     //@@author A0138961W
     @Override
     public synchronized void deleteTask(List<ReadOnlyTask> targets) throws TaskNotFoundException,
@@ -102,6 +102,7 @@ public class ModelManager extends ComponentManager implements Model {
         }
         indicateTaskBossChanged();
     }
+
     //@@author
     @Override
     public synchronized void addTask(Task task) throws IllegalValueException {
@@ -161,54 +162,8 @@ public class ModelManager extends ComponentManager implements Model {
     public void renameCategory(Category oldCategory, Category newCategory)
             throws IllegalValueException, CommandException, DuplicateCategoryException {
         assert oldCategory != null;
-
-        boolean isFound = false;
-
         taskbossHistory.push(new TaskBoss(this.taskBoss));
-        FilteredList<ReadOnlyTask> oldCategoryTaskList = filteredTasks;
-        int listSize = oldCategoryTaskList.size();
-
-        // remember all tasks
-        ArrayList<ReadOnlyTask> allReadOnlyTasks = new ArrayList<ReadOnlyTask> ();
-        for (ReadOnlyTask task : oldCategoryTaskList) {
-            allReadOnlyTasks.add(task);
-        }
-
-        // remember all task index
-        int[] taskIndex = new int[listSize];
-        for (int i = 0; i < listSize; i++) {
-            taskIndex[i] = oldCategoryTaskList.getSourceIndex(i);
-        }
-
-        for (int i = 0; i < listSize; i++) {
-            // get each task on the filtered task list
-            ReadOnlyTask target = allReadOnlyTasks.get(i);
-            // get the UniqueCategoryList of the task
-            UniqueCategoryList targetCategoryList = target.getCategories();
-
-            UniqueCategoryList newCategoryList = new UniqueCategoryList();
-
-            try {
-                for (Category category : targetCategoryList) {
-                    if (category.equals(oldCategory)) {
-                        isFound = true;
-                        newCategoryList.add(newCategory);
-                    } else {
-                        newCategoryList.add(category);
-                    }
-                }
-            } catch (DuplicateCategoryException dce) {
-                throw new DuplicateCategoryException();
-            }
-
-            Task editedTask = new Task(target);
-            editedTask.setCategories(newCategoryList);
-            int taskBossIndex = taskIndex[i];
-            taskBoss.updateTask(taskBossIndex, editedTask);
-        }
-
-        errorDoesNotExistDetect(oldCategory, isFound);
-
+        taskBoss.renameCategory(newCategory, oldCategory);
         removeCategoryFromTaskboss(oldCategory);
         indicateTaskBossChanged();
     }
@@ -221,21 +176,6 @@ public class ModelManager extends ComponentManager implements Model {
         Task newRecurredTask = new Task(taskToMarkDone);
         newRecurredTask.getRecurrence().updateTaskDates(newRecurredTask);
         return newRecurredTask;
-    }
-
-    //@@author A0144904H
-    /**
-     * detects the category does not exist error
-     * @param oldCategory
-     * @param isFound
-     * @throws CommandException
-     */
-    private void errorDoesNotExistDetect(Category oldCategory, boolean isFound) throws CommandException {
-        if (!isFound) {
-            updateFilteredListToShowAll();
-            throw new CommandException(oldCategory.toString()
-                    + " " + RenameCategoryCommand.MESSAGE_DOES_NOT_EXIST_CATEGORY);
-        }
     }
 
     //=========== Filtered Task List Accessors =============================================================

--- a/src/main/java/seedu/taskboss/model/TaskBoss.java
+++ b/src/main/java/seedu/taskboss/model/TaskBoss.java
@@ -177,7 +177,6 @@ public class TaskBoss implements ReadOnlyTaskBoss {
         CommandException {
         categories.replace(newCategory, oldCategory);
         tasks.renameCategory(oldCategory, newCategory);
-      
     }
 
 //// util methods

--- a/src/main/java/seedu/taskboss/model/TaskBoss.java
+++ b/src/main/java/seedu/taskboss/model/TaskBoss.java
@@ -173,6 +173,12 @@ public class TaskBoss implements ReadOnlyTaskBoss {
         categories.remove(t);
     }
 
+    //@@authour A0143157J
+    /**
+     * Renames a category in TaskBoss.
+     * @throws IllegalValueException
+     * @throws CommandException
+     */
     public void renameCategory(Category newCategory, Category oldCategory) throws IllegalValueException,
         CommandException {
         categories.replace(newCategory, oldCategory);
@@ -181,6 +187,7 @@ public class TaskBoss implements ReadOnlyTaskBoss {
 
 //// util methods
 
+    //@@author
     @Override
     public String toString() {
         return tasks.asObservableList().size() + " tasks, " + categories.asObservableList().size() +  " categories";

--- a/src/main/java/seedu/taskboss/model/TaskBoss.java
+++ b/src/main/java/seedu/taskboss/model/TaskBoss.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import javafx.collections.ObservableList;
 import seedu.taskboss.commons.core.UnmodifiableObservableList;
 import seedu.taskboss.commons.exceptions.IllegalValueException;
+import seedu.taskboss.logic.commands.exceptions.CommandException;
 import seedu.taskboss.model.category.Category;
 import seedu.taskboss.model.category.UniqueCategoryList;
 import seedu.taskboss.model.task.ReadOnlyTask;
@@ -150,6 +151,7 @@ public class TaskBoss implements ReadOnlyTaskBoss {
         }
     }
 
+    //@@author A0143157J
     /**
      * Sorts tasks in TaskBoss according to these sort types:
      * - start date and time
@@ -169,6 +171,13 @@ public class TaskBoss implements ReadOnlyTaskBoss {
     //@@author A0147990R
     public void removeCategory(Category t) {
         categories.remove(t);
+    }
+
+    public void renameCategory(Category newCategory, Category oldCategory) throws IllegalValueException,
+        CommandException {
+        categories.replace(newCategory, oldCategory);
+        tasks.renameCategory(oldCategory, newCategory);
+      
     }
 
 //// util methods

--- a/src/main/java/seedu/taskboss/model/category/UniqueCategoryList.java
+++ b/src/main/java/seedu/taskboss/model/category/UniqueCategoryList.java
@@ -149,6 +149,21 @@ public class UniqueCategoryList implements Iterable<Category> {
         }
     }
 
+    //@@author A0143157J
+    /**
+     * Replaces a Category in the list.
+     * On client-side, this operation is to rename a Category.
+     * @throws IllegalValueException
+     */
+    public void replace(Category newCategory, Category oldCategory) throws IllegalValueException {
+        for (Category category : this) {
+            if (category.categoryName.equals(new Category(oldCategory.categoryName))) {
+                this.remove(oldCategory);
+            }
+        }
+        this.add(newCategory);
+    }
+
     //@@author
     @Override
     public Iterator<Category> iterator() {
@@ -184,5 +199,6 @@ public class UniqueCategoryList implements Iterable<Category> {
             super("Operation would result in duplicate categories");
         }
     }
+
 
 }

--- a/src/main/java/seedu/taskboss/model/task/Task.java
+++ b/src/main/java/seedu/taskboss/model/task/Task.java
@@ -134,7 +134,7 @@ public class Task implements ReadOnlyTask {
     }
 
     /**
-     * Updates this person with the details of {@code replacement}.
+     * Updates this task with the details of {@code replacement}.
      */
     public void resetData(ReadOnlyTask replacement) {
         assert replacement != null;

--- a/src/main/java/seedu/taskboss/model/task/UniqueTaskList.java
+++ b/src/main/java/seedu/taskboss/model/task/UniqueTaskList.java
@@ -173,7 +173,7 @@ public class UniqueTaskList implements Iterable<Task> {
     /**
      * Renames a certain category in tasks to another specified name.
      * @throws IllegalValueException
-     * @throws CommandException 
+     * @throws CommandException
      */
     public void renameCategory(Category oldCategory, Category newCategory) throws IllegalValueException,
         CommandException {

--- a/src/main/java/seedu/taskboss/model/task/UniqueTaskList.java
+++ b/src/main/java/seedu/taskboss/model/task/UniqueTaskList.java
@@ -171,7 +171,7 @@ public class UniqueTaskList implements Iterable<Task> {
 
     //@@author A0143157J
     /**
-     * Renames a certain category in tasks to another specified name.
+     * Renames a certain category for all tasks in this category.
      * @throws IllegalValueException
      * @throws CommandException
      */

--- a/src/main/java/seedu/taskboss/model/task/UniqueTaskList.java
+++ b/src/main/java/seedu/taskboss/model/task/UniqueTaskList.java
@@ -11,7 +11,12 @@ import seedu.taskboss.commons.core.UnmodifiableObservableList;
 import seedu.taskboss.commons.exceptions.DuplicateDataException;
 import seedu.taskboss.commons.exceptions.IllegalValueException;
 import seedu.taskboss.commons.util.CollectionUtil;
+import seedu.taskboss.logic.commands.RenameCategoryCommand;
 import seedu.taskboss.logic.commands.SortCommand;
+import seedu.taskboss.logic.commands.exceptions.CommandException;
+import seedu.taskboss.model.category.Category;
+import seedu.taskboss.model.category.UniqueCategoryList;
+import seedu.taskboss.model.category.UniqueCategoryList.DuplicateCategoryException;
 
 /**
  * A list of tasks that enforces uniqueness between its elements and does not allow nulls.
@@ -164,6 +169,53 @@ public class UniqueTaskList implements Iterable<Task> {
         return taskFoundAndDeleted;
     }
 
+    //@@author A0143157J
+    /**
+     * Renames a certain category in tasks to another specified name.
+     * @throws IllegalValueException
+     * @throws CommandException 
+     */
+    public void renameCategory(Category oldCategory, Category newCategory) throws IllegalValueException,
+        CommandException {
+        assert oldCategory != null;
+
+        boolean isFound = false;
+
+        for (Task task : this) {
+            UniqueCategoryList targetCategoryList = task.getCategories();
+            UniqueCategoryList newCategoryList = new UniqueCategoryList();
+            try {
+                for (Category category : targetCategoryList) {
+                    if (category.equals(oldCategory)) {
+                        isFound = true;
+                        newCategoryList.add(newCategory);
+                    } else {
+                        newCategoryList.add(category);
+                    }
+                }
+            } catch (DuplicateCategoryException dce) {
+                throw new DuplicateCategoryException();
+            }
+            task.setCategories(newCategoryList);
+        }
+        errorDoesNotExistDetect(oldCategory, isFound);
+    }
+
+    //@@author A0144904H
+    /**
+     * detects the category does not exist error
+     * @param oldCategory
+     * @param isFound
+     * @throws CommandException
+     */
+    private void errorDoesNotExistDetect(Category oldCategory, boolean isFound) throws CommandException {
+        if (!isFound) {
+            throw new CommandException(oldCategory.toString()
+                    + " " + RenameCategoryCommand.MESSAGE_DOES_NOT_EXIST_CATEGORY);
+        }
+    }
+
+    //@@author
     public void setTasks(UniqueTaskList replacement) {
         this.internalList.setAll(replacement.internalList);
     }

--- a/src/test/java/guitests/RenameCategoryCommandTest.java
+++ b/src/test/java/guitests/RenameCategoryCommandTest.java
@@ -35,7 +35,7 @@ public class RenameCategoryCommandTest extends TaskBossGuiTest {
                 .withStartDateTime("Feb 18, 2017 5pm")
                 .withEndDateTime("Mar 28, 2017 5pm")
                 .withRecurrence(Frequency.NONE)
-                .withCategories("Project", AddCommand.DEFAULT_ALL_TASKS).build();
+                .withCategories(AddCommand.DEFAULT_ALL_TASKS, "Project").build();
         sampleB = new TaskBuilder().withName("Birthday party")
                 .withInformation("311, Clementi Ave 2, #02-25")
                 .withPriorityLevel("No")

--- a/src/test/java/guitests/RenameCategoryCommandTest.java
+++ b/src/test/java/guitests/RenameCategoryCommandTest.java
@@ -1,5 +1,3 @@
-
-
 package guitests;
 
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/guitests/RenameCategoryCommandTest.java
+++ b/src/test/java/guitests/RenameCategoryCommandTest.java
@@ -20,12 +20,12 @@ public class RenameCategoryCommandTest extends TaskBossGuiTest {
 
     @Test
     public void renameCategory_Long_Command_success() throws IllegalValueException {
-        assertRenameCategoryResult("name friends Project");
+        assertRenameCategoryResult("rename friends Project");
     }
 
     @Test
     public void renameCategory_Short_Command_success() throws IllegalValueException {
-        assertRenameCategoryResult("n friends Project");
+        assertRenameCategoryResult("r friends Project");
     }
 
     private void assertRenameCategoryResult(String command) throws IllegalValueException {
@@ -57,45 +57,45 @@ public class RenameCategoryCommandTest extends TaskBossGuiTest {
     public void rename_unsuccessful() {
 
         //old category name == new category name
-        commandBox.runCommand("name friends friends");
+        commandBox.runCommand("rename friends friends");
         assertResultMessage(RenameCategoryCommandParser.ERROR_SAME_FIELDS);
 
         //invalid number of fields
-        commandBox.runCommand("name friends bestfriends forever");
+        commandBox.runCommand("rename friends bestfriends forever");
         assertResultMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RenameCategoryCommand.MESSAGE_USAGE));
 
         //category name with a single non-alphanumerical character
-        commandBox.runCommand("name owesMoney myMoney!");
+        commandBox.runCommand("rename owesMoney myMoney!");
         assertResultMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 RenameCategoryCommandParser.ERROR_NON_ALPHANUMERIC));
 
         //category name with all non-alphanumerical characters
-        commandBox.runCommand("name owesMoney !!!");
+        commandBox.runCommand("rename owesMoney !!!");
         assertResultMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 RenameCategoryCommandParser.ERROR_NON_ALPHANUMERIC));
 
         //category name does not exist
-        commandBox.runCommand("name superman batman");
+        commandBox.runCommand("rename superman batman");
         assertResultMessage("[superman] " + RenameCategoryCommand.MESSAGE_DOES_NOT_EXIST_CATEGORY);
 
         //category name is AllTasks
-        commandBox.runCommand("name AllTasks batman");
+        commandBox.runCommand("rename AllTasks batman");
         assertResultMessage(RenameCategoryCommand.MESSAGE_ALL_TASK_CATEGORY_CANNOT_RENAME);
 
         //category name is Done
-        commandBox.runCommand("name Done batman");
+        commandBox.runCommand("rename Done batman");
         assertResultMessage(RenameCategoryCommand.MESSAGE_DONE_CATEGORY_CANNOT_RENAME);
 
         //rename category to Done
-        commandBox.runCommand("name owesMoney Done");
+        commandBox.runCommand("rename owesMoney Done");
         assertResultMessage(RenameCategoryCommand.MESSAGE_CATEGORY_CANNOT_RENAME_TO_DONE);
 
         //rename category to AllTasks
-        commandBox.runCommand("name owesMoney AllTasks");
+        commandBox.runCommand("rename owesMoney AllTasks");
         assertResultMessage(RenameCategoryCommand.MESSAGE_CATEGORY_CANNOT_RENAME_TO_ALL_TASKS);
 
         //duplicate category
-        commandBox.runCommand("name owesMoney friends");
+        commandBox.runCommand("rename owesMoney friends");
         assertResultMessage(RenameCategoryCommand.MESSAGE_DUPLICATE_CATEGORY);
     }
 }

--- a/src/test/java/guitests/RenameCategoryCommandTest.java
+++ b/src/test/java/guitests/RenameCategoryCommandTest.java
@@ -18,12 +18,12 @@ public class RenameCategoryCommandTest extends TaskBossGuiTest {
 
     @Test
     public void renameCategory_Long_Command_success() throws IllegalValueException {
-        assertRenameCategoryResult("rename friends Project");
+        assertRenameCategoryResult("name friends Project");
     }
 
     @Test
     public void renameCategory_Short_Command_success() throws IllegalValueException {
-        assertRenameCategoryResult("r friends Project");
+        assertRenameCategoryResult("n friends Project");
     }
 
     private void assertRenameCategoryResult(String command) throws IllegalValueException {
@@ -50,50 +50,60 @@ public class RenameCategoryCommandTest extends TaskBossGuiTest {
         assertTrue(taskListPanel.isListMatching(taskListExpected));
     }
 
-
     @Test
     public void rename_unsuccessful() {
 
         //old category name == new category name
-        commandBox.runCommand("rename friends friends");
+        commandBox.runCommand("name friends friends");
         assertResultMessage(RenameCategoryCommandParser.ERROR_SAME_FIELDS);
 
         //invalid number of fields
-        commandBox.runCommand("rename friends bestfriends forever");
+        commandBox.runCommand("name friends bestfriends forever");
         assertResultMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RenameCategoryCommand.MESSAGE_USAGE));
 
         //category name with a single non-alphanumerical character
-        commandBox.runCommand("rename owesMoney myMoney!");
+        commandBox.runCommand("name owesMoney myMoney!");
         assertResultMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 RenameCategoryCommandParser.ERROR_NON_ALPHANUMERIC));
 
         //category name with all non-alphanumerical characters
-        commandBox.runCommand("rename owesMoney !!!");
+        commandBox.runCommand("name owesMoney !!!");
         assertResultMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 RenameCategoryCommandParser.ERROR_NON_ALPHANUMERIC));
 
         //category name does not exist
-        commandBox.runCommand("rename superman batman");
+        commandBox.runCommand("name superman batman");
         assertResultMessage("[superman] " + RenameCategoryCommand.MESSAGE_DOES_NOT_EXIST_CATEGORY);
 
         //category name is AllTasks
-        commandBox.runCommand("rename AllTasks batman");
+        commandBox.runCommand("name AllTasks batman");
         assertResultMessage(RenameCategoryCommand.MESSAGE_ALL_TASK_CATEGORY_CANNOT_RENAME);
 
         //category name is Done
-        commandBox.runCommand("rename Done batman");
+        commandBox.runCommand("name Done batman");
         assertResultMessage(RenameCategoryCommand.MESSAGE_DONE_CATEGORY_CANNOT_RENAME);
 
         //rename category to Done
-        commandBox.runCommand("rename owesMoney Done");
+        commandBox.runCommand("name owesMoney Done");
         assertResultMessage(RenameCategoryCommand.MESSAGE_CATEGORY_CANNOT_RENAME_TO_DONE);
 
         //rename category to AllTasks
-        commandBox.runCommand("rename owesMoney AllTasks");
+        commandBox.runCommand("name owesMoney AllTasks");
         assertResultMessage(RenameCategoryCommand.MESSAGE_CATEGORY_CANNOT_RENAME_TO_ALL_TASKS);
+    }
 
-        //duplicate category
-        commandBox.runCommand("rename owesMoney friends");
+    //@@author A0143157J
+    //BVA: Duplicate categories in a task
+    @Test
+    public void rename_duplicate_categories_within_task_failure() {
+        commandBox.runCommand("name owesMoney friends");
+        assertResultMessage(RenameCategoryCommand.MESSAGE_DUPLICATE_CATEGORY);
+    }
+
+    //BVA: Duplicate categories in TaskBoss (but different tasks)
+    @Test
+    public void rename_duplicate_categories_within_taskboss_failure() {
+        commandBox.runCommand("name school owesMoney");
         assertResultMessage(RenameCategoryCommand.MESSAGE_DUPLICATE_CATEGORY);
     }
 }

--- a/src/test/java/seedu/taskboss/testutil/TypicalTestTasks.java
+++ b/src/test/java/seedu/taskboss/testutil/TypicalTestTasks.java
@@ -49,7 +49,8 @@ public class TypicalTestTasks {
                     .withStartDateTime("Feb 21, 2017 1pm")
                     .withEndDateTime("Dec 10, 2017 5pm")
                     .withRecurrence(Frequency.WEEKLY)
-                    .withInformation("little tokyo").build();
+                    .withInformation("little tokyo")
+                    .withCategories("school").build();
             taskG = new TaskBuilder().withName("Game project player testing").withPriorityLevel("Yes")
                     .withStartDateTime("Jan 1, 2017 5pm")
                     .withEndDateTime("Nov 28, 2017 5pm")


### PR DESCRIPTION
Bugs fixed:
* Attempt to have duplicate categories within taskboss will now return an error message (previously only checked duplicates within tasks)
* Rename duplicate categories will no longer result in disappearing user input

Added test cases